### PR TITLE
Update Kconfig for ARM64 and add compile tutorial for Odroidn2

### DIFF
--- a/init/Kconfig
+++ b/init/Kconfig
@@ -2358,7 +2358,7 @@ config ARCH_HAS_SYSCALL_WRAPPER
 
 config SCHED_CLASS_GHOST
 	bool "ghOSt scheduling class"
-	depends on X86_64
+	depends on (X86_64 || ARM64)
 	default n
 	help
 	  ghOSt is a scheduling class with policy decisions delegated

--- a/odroidn2_compile.md
+++ b/odroidn2_compile.md
@@ -32,6 +32,8 @@ Or
     $ uname -a to check the kernel
 ```
 It should output the new kernel version which is `5.11.0+`: ` Linux ubuntu 5.11.0+ #2 SMP PREEMPT Mon Apr 18 00:50:21 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux`
+
 9. Finally install the headers
 ` sudo make headers_install INSTALL_HDR_PATH=/usr`
+
 10. Have fun

--- a/odroidn2_compile.md
+++ b/odroidn2_compile.md
@@ -1,0 +1,37 @@
+0. Pre-request:
+    1. [Odroid n2 board](https://www.hardkernel.com/shop/odroid-n2-with-4gbyte-ram/) (n2+ should be fine, but I have not test it yet).
+    2. [Armbian linux image](https://www.armbian.com/odroid-n2/): the version of image I'm using is `Armbian_22.02.2_Odroidn2_focal_current_5.10.103`.
+1. Install required packages
+`
+    $sudo apt-get install git fakeroot build-essential ncurses-dev xz-utils libssl-dev bc flex libelf-dev bison -y
+`
+2. Clone the source code
+`$ git clone https://github.com/google/ghost-kernel.git && cd ghost_kernel`
+3. Copy the config file to source code directory 
+`$ cp /boot/cp /boot/config-5.10.103-meson64 .config `
+4. Remove the signature checking certificates
+`$ make menuconfig`
+Remove 'debian/canonical-certs.pem' in Cryptographic API -> Certificates for signature checking
+5. Start to compile  `make -j4`
+6. Install the kernel module
+`$ sudo make INSTALL_MOD_STRIP=1 modules_install # strip the modules to reduce the size of initrd`
+Or
+```
+    $ sudo make install
+    $ cd /lib/modules/<new_kernel> 
+    $ find . -name *.ko -exec strip --strip-unneeded {} +
+```
+7.  After executing above command, proceed to create initramfs/initrd
+```
+    $ sudo make install
+    $ sudo ln -s vmlinuz-5.11.0+ Image
+```
+8. Reboot and check the version of new kernel
+```
+    $ sudo reboot 
+    $ uname -a to check the kernel
+```
+It should output the new kernel version which is `5.11.0+`: ` Linux ubuntu 5.11.0+ #2 SMP PREEMPT Mon Apr 18 00:50:21 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux`
+9. Finally install the headers
+` sudo make headers_install INSTALL_HDR_PATH=/usr`
+10. Have fun


### PR DESCRIPTION
This pull request is to update the Kconfig and add the compile tutorial for odroidn2 which is an ARM64 development board.
The configuration and compile tutorial could be adopted for other similiar ARM64 platforms.
I have tested the new ghost-kernel with ghost-userspace: antagonist and fifo_per_cpu_agent

Thanks.